### PR TITLE
Other(deps): Update devDependency standard to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "nyc": "nyc --reporter=text --reporter=text-summary --reporter=html --report-dir=docs/reports/coverage npm run mocha",
     "postnyc": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100"
   },
+  "standard": {
+    "env": [
+      "mocha"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/expediagroup/catalyst-server"
@@ -55,7 +60,7 @@
     "chai-as-promised": "^7.1.1",
     "nyc": "^14.1.1",
     "sinon": "^7.3.2",
-    "standard": "^13.0.2",
+    "standard": "^14.3.1",
     "mocha": "^6.1.4"
   },
   "dependencies": {


### PR DESCRIPTION
Updates the following dev dependency
standard (source) | devDependencies | major | ^13.0.2 -> ^14.0.0

Also adds ` "standard": {
    "env": [
      "mocha"
    ]
  }` to package json. 

Now running `standard --fix` will not show mocha functions as errors.
