### PR TITLE
Feature: Allow routes to be registered from a manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Below is a basic example of a `manifest.json` file:
             "method": "GET",
             "path": "/my-file.txt",
             "handler": {
-                "file": "my-file.txt"
+                "file": "path:./my-file.txt"
             }
         }
     ]

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ const server = await Catalyst.init({
 {
      // server configuration and application context variables.
     "server": {
-        "app": {
-        }
+        "app": {}
     },
     // Hapi plugins
-    "register": {
-    }
+    "register": {},
+    // Hapi routes
+    "routes": []
 }
 ```
 
@@ -91,11 +91,11 @@ Below is a basic example of a `manifest.json` file:
     },
     // Hapi plugins
     "register": {
-        "Inert": {
-            "register": "require:inert"
+        "inert": {
+            "plugin": "require:@hapi/inert"
         },
-        "Vision": {
-            "register": "require:vision",
+        "vision": {
+            "plugin": "require:@hapi/vision",
             "options": {
                 "engines": {
                     "html": "require:handlebars"
@@ -103,7 +103,17 @@ Below is a basic example of a `manifest.json` file:
                 "path": "path:./templates"
             }
         }
-    }
+    },
+    // Hapi routes
+    "routes": [
+        {
+            "method": "GET",
+            "path": "/my-file.txt",
+            "handler": {
+                "file": "my-file.txt"
+            }
+        }
+    ]
 }
 ```
 
@@ -149,7 +159,7 @@ Catalyst-server ships with the following `shortstop` resolvers by default:
     // Hapi plugins
     "register": {
         "crumb": {
-            "register": "require:crumb",
+            "plugin": "require:crumb",
             "options": {
                 "cookieOptions": {
                     "isSecure": {
@@ -229,7 +239,7 @@ Here are some examples of the `shortstop` resolvers which make handling complex 
 
 #### `require:` Require a javascript or json file.
 ```json
-    "register": "require:inert"
+    "plugin": "require:@hapi/inert"
 ```
 * will load the node module `inert` and will set the `register` to what that module exports. This works for js files in you application.
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -18,7 +18,8 @@ const Joi = require('joi')
 
 const manifestSchema = Joi.object().keys({
   register: Joi.object(),
-  server: Joi.object()
+  server: Joi.object(),
+  routes: Joi.array().items(Joi.object())
 })
 
 const defaults = {

--- a/package.json
+++ b/package.json
@@ -64,11 +64,12 @@
   },
   "devDependencies": {
     "@hapi/hapi": "^20.0.0",
+    "@hapi/inert": "^6.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "mocha": "^8.0.0",
     "nyc": "^15.1.0",
     "sinon": "^11.0.0",
-    "standard": "^16.0.0",
-    "mocha": "^8.0.0"
+    "standard": "^16.0.0"
   }
 }

--- a/tests/fixtures/manifest-routes.json
+++ b/tests/fixtures/manifest-routes.json
@@ -1,0 +1,16 @@
+{
+    "register": {
+        "inert": {
+            "plugin": "require:@hapi/inert"
+        }
+    },
+    "routes": [
+        {
+            "method": "GET",
+            "path": "/my-file.txt",
+            "handler": {
+                "file": "path:./my-file.txt"
+            }
+        }
+    ]
+}

--- a/tests/fixtures/my-file.txt
+++ b/tests/fixtures/my-file.txt
@@ -1,0 +1,1 @@
+hello-world

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -29,6 +29,17 @@ describe('Catalyst', () => {
     expect(server.info.port).to.equal(3000)
   })
 
+  it('should register provided routes', async () => {
+    const server = await Catalyst.init({
+      userConfigPath: Path.join(__dirname, '..', 'fixtures/manifest-routes.json')
+    })
+
+    const response = await server.inject('/my-file.txt')
+    expect(response.result).to.equal('hello-world')
+
+    await server.stop()
+  })
+
   describe('single manifest file passed to userConfigPath', () => {
     it('should load a plugin from a manifest', async () => {
       const server = await Catalyst.init({


### PR DESCRIPTION
Steerage [allows routes](https://github.com/ExpediaGroup/steerage/blob/master/lib/index.js#L97-L100) to be defined in a configuration file. This PR changes the options schema to allow `routes` to be defined in a manifest file.