### PR TITLE
Fix(deps): Review compatibility between hapi libraries

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -4,8 +4,12 @@
  * http://localhost:8080/hello
  */
 
-const Catalyst = require('../..')
-const Path = require('path')
+ const Catalyst = require('../..');
+ const Path = require('path');
+ const getResponse = [
+   {string: 'string1', number: 1, boolean: true},
+   {string: 'string2', number: 2, boolean: false},
+ ];
 
 async function start (options = {}) {
   const server = await Catalyst.init({
@@ -13,10 +17,10 @@ async function start (options = {}) {
     userConfigPath: Path.resolve(__dirname, 'manifest.json')
   })
   server.route({
-    path: '/hello',
+    path: '/items',
     method: 'GET',
     handler () {
-      return 'hello'
+      return getResponse;
     }
   })
   await server.start()

--- a/lib/config.json
+++ b/lib/config.json
@@ -38,13 +38,9 @@
         "hapi-pino":{
             "plugin": "require:hapi-pino",
             "options": {
-                "prettyPrint": {
-                    "$filter": "env.NODE_ENV",
-                    "production": false,
-                    "$default": {
-                        "translateTime": true
-                    }
-                }
+                "prettyPrint": "env.NODE_ENV || production",
+                // Redact Authorization headers, see https://getpino.io/#/docs/redaction
+                "redact": ["req.headers.authorization"]
             }
         }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Expedia Group, Inc.
+Copyright 2021 Expedia Group, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
     "@hapi/crumb": "^8.0.0",
     "@hapi/hoek": "^9.0.4",
     "@vrbo/steerage": "^10.0.0",
-    "hapi-pino": "^8.1.0",
+    "hapi-pino": "^8.5.0",
     "joi": "^17.2.0",
-    "shortstop-handlers": "^1.0.1"
+    "shortstop-handlers": "^1.0.1",
+    "@hapi/hapi": "^20.2.1",
+    "@hapi/inert": "^6.0.3"
   },
   "devDependencies": {
-    "@hapi/hapi": "^20.2.1",
-    "@hapi/inert": "^6.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -56,13 +56,13 @@
   },
   "dependencies": {
     "@hapi/crumb": "^8.0.0",
+    "@hapi/hapi": "^20.2.1",
     "@hapi/hoek": "^9.0.4",
-    "@vrbo/steerage": "^10.0.0",
+    "@hapi/inert": "^6.0.3",
+    "@vrbo/steerage": "^11.0.1",
     "hapi-pino": "^8.5.0",
     "joi": "^17.2.0",
-    "shortstop-handlers": "^1.0.1",
-    "@hapi/hapi": "^20.2.1",
-    "@hapi/inert": "^6.0.3"
+    "shortstop-handlers": "^1.0.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
this pr will add the necessary versions compatible for @hapi/hapi - @hapi-pino.

See the release note at [hapi-pino-release/tag/v.8.2.0](https://github.com/pinojs/hapi-pino/releases/tag/v8.2.0 )

And more details regarding the error at the [slack conversation](https://expedia.slack.com/archives/G013MEA3GMS/p1635517558002800)