### PR TITLE
feat: exposes overrides and defaults from steerage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ const server = await Catalyst.init({
 }
 ```
 
+## `Catalyst.init()` Options
+
+-   `userConfigPath` - Path to the json configuration file (see examples).
+-   `onConfig` - Hook for modifying config prior to creating list of plugins to register (can be async). `(config) => {return config;}`
+-   `defaults` - default pre-resolved configuration values. Can be an object or a path to a json file.
+-   `overrides` - optional override pre-resolved configuration values. Can be an object or a path to a json file.
+-   `baseDir` - Alternative location to base [shortstop](https://github.com/krakenjs/shortstop) relative paths from.
+-   `environment` - Additional criteria for [confidence](https://github.com/hapijs/confidence) property resolution and defaults to `{ env: process.env }`.
+-   `shortstopHandlers` - Object for additional shortstop handlers.
+
 ## Configuration and Composition
 
 Catalyst-server uses [`@vrbo/steerage`](https://github.com/expediagroup/steerage) to configure and compose your application.  It is environment aware and has some configuration protocols to resolve paths, read environment variables, import other JSON files, and more.

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,9 @@ const init = async function (options = {}) {
     baseDir,
     onConfig,
     environment,
-    shortstopHandlers
+    shortstopHandlers,
+    defaults,
+    overrides
   } = await optionsSchema.validateAsync(options)
 
   const baseConfig = Path.join(__dirname, 'config.json')
@@ -74,7 +76,9 @@ const init = async function (options = {}) {
     ],
     environment,
     onconfig: onConfig,
-    protocols: shortstopHandlers
+    protocols: shortstopHandlers,
+    defaults,
+    overrides
   })
 
   // shutdown gracefully

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -29,8 +29,10 @@ const defaults = {
 
 const optionsSchema = Joi.object({
   baseDir: Joi.string(),
+  defaults: Joi.alternatives(Joi.string(), Joi.object()).default({}),
   environment: Joi.object().default(defaults.environment),
   onConfig: Joi.func(),
+  overrides: Joi.alternatives(Joi.string(), Joi.object()).default({}),
   shortstopHandlers: Joi.object().default(defaults.shortstopHandlers),
   userConfigPath: Joi.array().items(Joi.string()).single().default([])
 }).default(defaults)

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
   "dependencies": {
     "@hapi/crumb": "^8.0.0",
     "@hapi/hoek": "^9.0.4",
-    "@vrbo/steerage": "^12.0.0",
+    "@vrbo/steerage": "^12.1.0",
     "hapi-pino": "^9.0.0",
-    "pino-pretty": "^7.2.0",
     "joi": "^17.2.0",
+    "pino-pretty": "^7.2.0",
     "shortstop-handlers": "^1.0.1"
   },
   "devDependencies": {

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -268,8 +268,8 @@ describe('Catalyst', () => {
             }
           }
         })
-    
-        expect(server.app.config.get("foo")).to.equal('bar')
+
+        expect(server.app.config.get('foo')).to.equal('bar')
       })
 
       it('should apply an overrides object to the config', async () => {
@@ -283,8 +283,8 @@ describe('Catalyst', () => {
             }
           }
         })
-    
-        expect(server.app.config.get("foo")).to.equal('bar')
+
+        expect(server.app.config.get('foo')).to.equal('bar')
       })
     })
   })

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -255,5 +255,37 @@ describe('Catalyst', () => {
 
       return expect(promise).to.be.rejectedWith(Error)
     })
+
+    describe('should use determination properties `defaults` and `overrides`', () => {
+      it('should apply a defaults object to the config', async () => {
+        const server = await Catalyst.init({
+          userConfigPath: Path.join(__dirname, '..', 'fixtures/manifest.json'),
+          defaults: {
+            server: {
+              app: {
+                foo: 'bar'
+              }
+            }
+          }
+        })
+    
+        expect(server.app.config.get("foo")).to.equal('bar')
+      })
+
+      it('should apply an overrides object to the config', async () => {
+        const server = await Catalyst.init({
+          userConfigPath: Path.join(__dirname, '..', 'fixtures/manifest.json'),
+          overrides: {
+            server: {
+              app: {
+                foo: 'bar'
+              }
+            }
+          }
+        })
+    
+        expect(server.app.config.get("foo")).to.equal('bar')
+      })
+    })
   })
 })


### PR DESCRIPTION
Determination has two additional properties that are now exposed by Steerage. This PR exposes them as `Catalyst.init()` options. These properties allow us to pass in objects as config, prior to the determination resolution.