### PR TITLE
Upgrade hapi pino to 911

### DIFF
--- a/examples/simple/manifest.json
+++ b/examples/simple/manifest.json
@@ -1,5 +1,6 @@
 {
     "server": {
+        "debug": false
     },
     "register": {
         "hapi-pino": {
@@ -18,10 +19,10 @@
                     "target": "pino-pretty",
                     "options": {
                         "singleLine": true,
-                        "colorize": true,
-                        "mkdir": true,
-                        "append": false,
-                        "destination": "logs/output.log"
+                        "colorize": true
+                        // "mkdir": true,
+                        // "append": false,
+                        // "destination": "logs/output.log"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@hapi/crumb": "^8.0.0",
     "@hapi/hoek": "^9.0.4",
     "@vrbo/steerage": "^12.1.3",
-    "hapi-pino": "^9.0.0",
+    "hapi-pino": "^9.1.1",
     "joi": "^17.2.0",
     "pino-pretty": "^7.2.0",
     "shortstop-handlers": "^1.0.1"


### PR DESCRIPTION
Our server was failing with the following.

<img width="959" alt="Screen Shot 2022-01-27 at 7 40 19" src="https://user-images.githubusercontent.com/88118994/151370261-139d305e-578f-4a62-a3bf-585d2f2d21ab.png">


> The issue was solved at https://github.com/pinojs/hapi-pino/pull/149


See more info regarding the issue at:
https://github.com/pinojs/hapi-pino/issues/145