### PR TITLE
New item added to the init options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ const server = await Catalyst.init({
 -   `baseDir` - Alternative location to base [shortstop](https://github.com/krakenjs/shortstop) relative paths from.
 -   `environment` - Additional criteria for [confidence](https://github.com/hapijs/confidence) property resolution and defaults to `{ env: process.env }`.
 -   `shortstopHandlers` - Object for additional shortstop handlers.
+-   `enableShutdownListeners` - Flag indicator for enabling or disabling execution of shutdown listeners, default 'true'
 
 ## Configuration and Composition
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ const { manifestSchema, optionsSchema } = require('./schemas')
  * @param {object} options.onConfig - hook for config loaded
  * @param {object} options.environment - the environment to use for criteria in config
  * @param {object} options.shortstopHandlers - addition shortstop handler to use in config
+ * @param {boolean} options.enableShutdownListeners - flag for enabling or disabling execution of shutdown listeners, default 'true'
  */
 const init = async function (options = {}) {
   let {
@@ -36,6 +37,7 @@ const init = async function (options = {}) {
     onConfig,
     environment,
     shortstopHandlers,
+    enableShutdownListeners,
     defaults,
     overrides
   } = await optionsSchema.validateAsync(options)
@@ -94,9 +96,12 @@ const init = async function (options = {}) {
   }
 
   /* istanbul ignore next */
-  process.once('SIGINT', end)
-  /* istanbul ignore next */
-  process.once('SIGTERM', end)
+  if (enableShutdownListeners) {
+    /* istanbul ignore next */
+    process.once('SIGINT', end)
+    /* istanbul ignore next */
+    process.once('SIGTERM', end)
+  }
 
   return server
 }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -24,7 +24,8 @@ const manifestSchema = Joi.object().keys({
 
 const defaults = {
   environment: { env: process.env },
-  shortstopHandlers: {}
+  shortstopHandlers: {},
+  enableShutdownListeners: true
 }
 
 const optionsSchema = Joi.object({
@@ -34,7 +35,8 @@ const optionsSchema = Joi.object({
   onConfig: Joi.func(),
   overrides: Joi.alternatives(Joi.string(), Joi.object()).default({}),
   shortstopHandlers: Joi.object().default(defaults.shortstopHandlers),
-  userConfigPath: Joi.array().items(Joi.string()).single().default([])
+  userConfigPath: Joi.array().items(Joi.string()).single().default([]),
+  enableShutdownListeners: Joi.boolean().default(defaults.enableShutdownListeners)
 }).default(defaults)
 
 module.exports = { manifestSchema, optionsSchema }


### PR DESCRIPTION
New item called `enableShutdownListeners` has been added to the init options.

This is a flag indicator for enabling or disabling execution of shutdown listeners(gracefully shutdown).