### PR TITLE
feat: empty commit to trigger release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # [5.3.0](https://github.com/expediagroup/catalyst-server/compare/v5.2.1...v5.3.0) (2022-03-29)
 
-
 ### Features
 
 * small readme change to retrigger release ([707bcda](https://github.com/expediagroup/catalyst-server/commit/707bcda1eab529ea11523324ce303784d9b7d8e5))


### PR DESCRIPTION
The prior change set used the wrong release token and failed to produce a release; this corrects that.